### PR TITLE
Don't show detached action in checkbox selection.

### DIFF
--- a/src/DetachedAction.php
+++ b/src/DetachedAction.php
@@ -18,11 +18,11 @@ abstract class DetachedAction extends Action
     public $showOnIndexToolbar = true;
 
     /**
-     * Indicates if this action is only available on the resource index view.
+     * Indicates if this action is available on the resource index view.
      *
      * @var bool
      */
-    public $onlyOnIndex = true;
+    public $showOnIndex = false;
 
     /**
      * The displayable label of the button.


### PR DESCRIPTION
Since detached actions is independent, it makes sense for us not to show it in checkbox selection.